### PR TITLE
Wrap chart updating in runOutsideAngular

### DIFF
--- a/src/morris-chart.directive.ts
+++ b/src/morris-chart.directive.ts
@@ -47,7 +47,7 @@ export class MorrisChartDirective implements OnInit, AfterViewInit, OnChanges, O
     } else {
       this.ngZone.runOutsideAngular(() => {
         this.chartInstance = new this.window.Morris[this.type](this._options);
-        this.chartInstance.on('click', (i, row) => { 
+        this.chartInstance.on('click', (i, row) => {
           this.clickChart.emit({ event, i, row });
         });
       });
@@ -61,8 +61,10 @@ export class MorrisChartDirective implements OnInit, AfterViewInit, OnChanges, O
    */
   ngOnChanges(changes: SimpleChanges) {
     if((changes.data && !changes.data.firstChange) || (changes.options && !changes.options.firstChange)) {
-      Object.assign(this.chartInstance.options, this.options);
-      this.chartInstance.setData(this.data);
+      this.ngZone.runOutsideAngular(() => {
+        Object.assign(this.chartInstance.options, this.options);
+        this.chartInstance.setData(this.data);
+      });
     }
   }
 


### PR DESCRIPTION
Ran into a performance issue with this lib and Angular 9 Ivy (I don't know if this is related to Angular 9 or not, haven't tried to downgrade and compare).  When updating the chart's data, it sometimes would take a minute or two to re-draw the chart, during which time the app would eat 100% CPU of the Chrome process.  Profiling the process, it seemed to come from Timer calls, but not sure where they were originating from.

This change wraps the Chart update process in a `runOutsideAngular` call, similar to how the chart initialization process is done. This appears to greatly reduce the CPU usage when re-drawing the chart. I assume this has something to do with Angular trying to manage all of the SVG elements created when the chart is re-drawn, but not entirely sure.

There doesn't appear to be any negative side effects to doing this, as Angular doesn't need to monitor anything that the chart is building, but please correct me if I'm wrong.

We've since further optimized the code that triggers the chart redraw (by modifying the options and/or data less frequently and in batches) so the impact isn't as big as what we were seeing initially, but there's still a significant reduction in CPU usage for a chart redraw with these changes in place:

### Without these changes (each peak is a chart redraw)

![Screen Shot 2020-09-15 at 10 30 13 AM](https://user-images.githubusercontent.com/136907/93238611-e9c11680-f73e-11ea-81ae-e7d6bbfa8d9b.png)

### With these changes

![Screen Shot 2020-09-15 at 10 25 02 AM](https://user-images.githubusercontent.com/136907/93238656-f47bab80-f73e-11ea-94c6-cdbc3717a361.png)

The time scale is the same in both of these screenshots from Chrome's Performance Monitor, I just screenshotted different lengths of the timeline.
